### PR TITLE
List processes with name

### DIFF
--- a/getinfo/disk.go
+++ b/getinfo/disk.go
@@ -19,7 +19,7 @@ func DiskInfo() {
 	writer := new(tabwriter.Writer)
 
 	// Format in tab-separated columns with a tab stop of 8.
-	writer.Init(os.Stdout, 0, 8, 0, '\t', 0)
+	writer.Init(os.Stdout, 0, 8, 8, '\t', tabwriter.AlignRight)
 
 	fmt.Fprintf(writer, "Drive\t%% Used\tTotal\tUsed\tFree\n")
 

--- a/getinfo/disk.go
+++ b/getinfo/disk.go
@@ -2,8 +2,10 @@ package getinfo
 
 import (
 	"fmt"
-	"strconv"
+	"os"
+	"text/tabwriter"
 
+	"github.com/dustin/go-humanize"
 	"github.com/shirou/gopsutil/disk"
 )
 
@@ -14,19 +16,25 @@ func DiskInfo() {
 
 	var usage []*disk.UsageStat
 
+	writer := new(tabwriter.Writer)
+
+	// Format in tab-separated columns with a tab stop of 8.
+	writer.Init(os.Stdout, 0, 8, 0, '\t', 0)
+
+	fmt.Fprintf(writer, "Drive\t%% Used\tTotal\tUsed\tFree\n")
+
 	for _, part := range parts {
 		u, err := disk.Usage(part.Mountpoint)
 		check(err)
 		usage = append(usage, u)
-		printUsage(u)
+		printUsage(u, writer)
 	}
 }
 
-func printUsage(u *disk.UsageStat) {
-	fmt.Printf(u.Path + "\t" + strconv.FormatFloat(u.UsedPercent, 'f', 2, 64) + "%% full \t")
-	fmt.Printf("Total \t: " + strconv.FormatUint(u.Total/1024/1024/1024, 10) + " GiB \t")
-	fmt.Printf("Free \t:  " + strconv.FormatUint(u.Free/1024/1024/1024, 10) + " GiB \t")
-	fmt.Printf("Used \t:  " + strconv.FormatUint(u.Used/1024/1024/1024, 10) + " GiB \n")
+func printUsage(u *disk.UsageStat, writer *tabwriter.Writer) {
+	fmt.Fprintf(writer, "%v\t%v%%\t%v\t%v\t%v\n", u.Path, int(u.UsedPercent), humanize.Bytes(u.Total), humanize.Bytes(u.Free),
+		humanize.Bytes(u.Used))
+	writer.Flush()
 }
 
 func check(err error) {

--- a/getinfo/process.go
+++ b/getinfo/process.go
@@ -3,6 +3,8 @@ package getinfo
 import (
 	"fmt"
 	"log"
+	"os"
+	"text/tabwriter"
 
 	"github.com/shirou/gopsutil/process"
 )
@@ -14,15 +16,22 @@ func ProcessInfo() {
 		log.Fatal(err)
 	}
 
+	writer := new(tabwriter.Writer)
+
+	// Format in tab-separated columns with a tab stop of 8.
+	writer.Init(os.Stdout, 0, 8, 0, '\t', 0)
+
+	fmt.Fprintf(writer, "PID\tName\tCPU Usage\n")
+
 	for _, proc := range processes {
 		pid := proc.Pid
-		// (time.Sleep(time.Second * 1))
 
 		name, _ := proc.Name()
 		cpuPercent, _ := proc.CPUPercent()
 
 		if cpuPercent > 1 {
-			fmt.Printf("PID: %v \tName: %v \t\tCPU Usage: %v%%\n", pid, name, int(cpuPercent))
+			fmt.Fprintf(writer, "%v\t%v\t%v%%\n", pid, name, int(cpuPercent))
+			writer.Flush()
 		}
 	}
 }

--- a/getinfo/process.go
+++ b/getinfo/process.go
@@ -21,6 +21,8 @@ func ProcessInfo() {
 		name, _ := proc.Name()
 		cpuPercent, _ := proc.CPUPercent()
 
-		fmt.Printf("PID: %v \tName: %v \tCPU Usage: %v%%\n", pid, name, int(cpuPercent))
+		if cpuPercent > 1 {
+			fmt.Printf("PID: %v \tName: %v \t\tCPU Usage: %v%%\n", pid, name, int(cpuPercent))
+		}
 	}
 }

--- a/getinfo/process.go
+++ b/getinfo/process.go
@@ -19,8 +19,7 @@ func ProcessInfo() {
 	writer := new(tabwriter.Writer)
 
 	// Format in tab-separated columns with a tab stop of 8.
-	writer.Init(os.Stdout, 0, 8, 0, '\t', 0)
-
+	writer.Init(os.Stdout, 0, 8, 8, '\t', tabwriter.AlignRight)
 	fmt.Fprintf(writer, "PID\tName\tCPU Usage\n")
 
 	for _, proc := range processes {

--- a/getinfo/process.go
+++ b/getinfo/process.go
@@ -1,0 +1,26 @@
+package getinfo
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/shirou/gopsutil/process"
+)
+
+// ProcessInfo lists information about processes running on host machine
+func ProcessInfo() {
+	processes, err := process.Processes()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, proc := range processes {
+		pid := proc.Pid
+		// (time.Sleep(time.Second * 1))
+
+		name, _ := proc.Name()
+		cpuPercent, _ := proc.CPUPercent()
+
+		fmt.Printf("PID: %v \tName: %v \tCPU Usage: %v%%\n", pid, name, int(cpuPercent))
+	}
+}

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 	// p, _ := process.Processes()
 	// fmt.Printf("\nList of Processes Running: \n")
 	infoStat, _ := host.Info()
-	fmt.Printf("Total processes: %d\n", infoStat.Procs)
+	fmt.Printf("Total processes: %d\t", infoStat.Procs)
 	miscStat, _ := load.Misc()
 	fmt.Printf("Running processes: %d\n", miscStat.ProcsRunning)
 	getinfo.ProcessInfo()

--- a/main.go
+++ b/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"fmt"
 
-	"github.com/obviyus/goids/getinfo"
+	"goids/getinfo"
 
 	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/host"
+	"github.com/shirou/gopsutil/load"
 )
 
 func main() {
@@ -18,5 +20,9 @@ func main() {
 	//TODO: List all processes
 	// p, _ := process.Processes()
 	// fmt.Printf("\nList of Processes Running: \n")
-
+	infoStat, _ := host.Info()
+	fmt.Printf("Total processes: %d\n", infoStat.Procs)
+	miscStat, _ := load.Misc()
+	fmt.Printf("Running processes: %d\n", miscStat.ProcsRunning)
+	getinfo.ProcessInfo()
 }

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"goids/getinfo"
+	"github.com/obviyus/goids/getinfo"
 
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/host"

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/obviyus/goids/getinfo"
+	"goids/getinfo"
 
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/host"


### PR DESCRIPTION
Added listing all processes functionality according to #1. Some processes have CPU usage much too close to 0% (e.g. `2.3845704e-5`) which should probably be ignored. 

#### TODO:
- Ignore all processes with usage < 1%
- Add memory usage % to output